### PR TITLE
Rewrite README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 # Automation
 
-## Purpose
-Scripts and utilities for automating product uploads and data preparation for e-commerce platforms such as Mercado and Shopee.
+Utilities and scripts to automate product listing and data preparation for e-commerce platforms such as Mercado and Shopee.
 
-## Prerequisites
+## Features
+- Upload products to Mercado and Shopee with Selenium-based scripts.
+- Helpers for building spreadsheets and cleaning databases.
+- Automatic ChromeDriver download and caching.
+
+## Requirements
 - Python 3.11+
-- Google Chrome (ChromeDriver is handled automatically and cached locally)
-- Packages: `selenium`, `pandas`, `pywinauto`, `openpyxl`, `webdriver-manager`
+- Google Chrome
 - Windows environment for GUI automation
+- Python packages: `selenium`, `pandas`, `pywinauto`, `openpyxl`, `webdriver-manager`
 
-## Setup
+## Installation
 1. Clone this repository.
-2. Install the required packages:
+2. Install dependencies:
    ```bash
    pip install selenium pandas pywinauto openpyxl webdriver-manager
    ```
 3. Place the necessary Excel files inside the `数据/` directory.
 
-## Folder Structure
-- `src/` – core automation scripts for uploading products
-- `tools/` – helper utilities for building spreadsheets and processing databases
-- `数据/` – spreadsheet inputs (`mercado_products.xlsx`, `mercado_images.xlsx`, `shopee_products.xlsx`)
+## Repository Layout
+- `src/` – automation scripts
+  - `单文件-自动上新/` – single-file Mercado uploader
+  - `多模块-自动上新/` – modular upload framework for Mercado and Shopee
+- `tools/` – utilities for generating spreadsheets and processing databases
+- `数据/` – input spreadsheets (`mercado_products.xlsx`, `mercado_images.xlsx`, `shopee_products.xlsx`)
 
-## Data Requirements
-The automation scripts expect product and image information in Excel spreadsheets located in `数据/`. Typical files include:
-- `mercado_products.xlsx` and `mercado_images.xlsx` for Mercado uploads
-- `shopee_products.xlsx` for Shopee listings
+## Preparing Data
+The scripts expect product and image information in Excel format. Place the files mentioned above in `数据/` before running any automation.
 
-## ChromeDriver Caching
-On the first run, the scripts download a matching ChromeDriver into the
-repository's `drivers/` directory and reuse it on subsequent runs. To use a
-custom driver path, set the `CHROME_DRIVER_PATH` environment variable before
-launching a script:
+## ChromeDriver
+On first execution the required ChromeDriver is downloaded to `drivers/` and reused on subsequent runs. To specify a custom driver path, set `CHROME_DRIVER_PATH` before launching a script:
 
 ```bash
-export CHROME_DRIVER_PATH=/path/to/chromedriver  # Linux/macOS
-set CHROME_DRIVER_PATH=C:\path\to\chromedriver.exe  # Windows
+export CHROME_DRIVER_PATH=/path/to/chromedriver      # Linux/macOS
+set CHROME_DRIVER_PATH=C:\path\to\chromedriver.exe # Windows
 ```
 
+## Usage
+Example: run the single-file Mercado upload script:
 
-## Example Usage
-Run a single-file Mercado upload script:
 ```bash
 python src/单文件-自动上新/mercado_自动上新.py
 ```


### PR DESCRIPTION
## Summary
- rewrite README with clearer feature overview and installation instructions

## Testing
- `pytest` *(fails: ImportError: cannot import name 'WinDLL' from 'ctypes')*

------
https://chatgpt.com/codex/tasks/task_e_689413ae04c88325af70c0d4868d510f